### PR TITLE
cities search improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_BASE_BACKEND_URL: https://scrapi.gsic.uva.es
+          VITE_BASE_API_PREFIX: /api
+          VITE_WORLDCLIM_API_KEY: ${{ secrets.WORLDCLIM_API_KEY }}
+          VITE_NODE_ENV: production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,161 @@
+# CLAUDE.md
+
+## Principles
+
+- Clarity and consistency over cleverness. Minimal changes. Match existing patterns.
+- Keep components/functions short; break down when it improves structure.
+- TypeScript everywhere; no `any` unless isolated and necessary.
+- No unnecessary `try/catch`. Avoid casting; use narrowing.
+- Named exports only (no default exports, except Next.js pages).
+- Absolute imports via `@/` unless same directory.
+- Follow existing ESLint setup; don't reformat unrelated code.
+- Let compiler infer return types unless annotation adds clarity.
+- Options object for 3+ params, optional flags, or ambiguous args.
+- Hypothesis-driven debugging: 1-3 causes, validate most likely first.
+
+## Commands
+
+- `npm run dev` — start dev server
+- `npm run build` — type-check + build
+- `npm run lint` — ESLint
+- `npm run type-check` — tsc --noEmit
+- `npm run format` — Prettier write
+- `npm run check` — type-check + lint + format:check
+
+## Environment Variables
+
+All env vars validated in `src/env.ts` with Zod. Never read `process.env`
+or `import.meta.env` directly — always use `GLOBAL_CONFIG` from
+`src/global-config.ts`.
+
+## Architecture
+
+### Data Flow
+
+Component → custom hook (src/hooks/) → Service (src/api/services/) → axiosInstance
+
+- Components consume hooks only — never import services directly
+- Services are plain objects with async methods — no hooks, no React inside
+- All data fetching via useQuery/useMutation with staleTime: Infinity for WorldClim
+
+### State
+
+- TanStack Query — server/remote state
+- Zustand — persisted auth + user info
+- URL search params — filters, active tab, selected city
+- useState — UI-only (open/closed, hover)
+- Never store derived data in state
+
+### Page Pattern
+
+Split every page into container (data + state) and view (pure rendering).
+Container fetches, handles events. View receives props, renders only.
+
+## TypeScript — STRICT FILE PLACEMENT RULES
+
+These rules are non-negotiable. Violations must be fixed before committing.
+
+TYPES: Declare ONLY in `*.type.ts` files. Never inline in components,
+utils, hooks, or constants. Export from `.type.ts`, import where needed.
+
+ENUMS: Declare ONLY in `*.enum.ts` files in `src/enums/`.
+
+INTERFACES: Only when a class implements it. Use `type T...` for data shapes.
+
+CONSTANTS: Declare ONLY in `*.constant.ts` files in `src/constants/`.
+
+UTILITIES: Declare ONLY in `*.util.ts` files.
+
+WRONG — never do this:
+// inside MyComponent.tsx or myUtil.ts
+type TMyThing = { ... }; // NO
+interface IMyThing { ... } // NO
+enum EMyEnum { ... } // NO
+const MY_CONSTANT = "value"; // NO (if reused elsewhere)
+
+CORRECT:
+// MyComponent.type.ts
+export type TMyThing = { ... };
+
+// myEnum.enum.ts
+export enum EMyEnum { ... }
+
+// myConstant.constant.ts
+export const MY_CONSTANT = "value";
+
+### Naming
+
+- Types/unions: `T` prefix — `TClimatePeriod`
+- Enums: `E` prefix — `EDataset`
+- Component props: `Props` suffix — `ClimateChartProps`
+- Interfaces (rare): `I` prefix — `IRepository`
+
+### No type assertions
+
+Never use `as`. Use type guards or proper generics instead.
+
+## Components
+
+Folder structure — required:
+ComponentName/
+ComponentName.tsx
+ComponentName.type.ts
+ComponentName.util.ts (if needed)
+ComponentName.constant.ts (if needed)
+index.ts
+
+Rules:
+
+- Max ~100 lines per component, ~30 lines per function
+- Presentational components: no side effects, props only
+- No business logic inside components — extract to hooks or utils
+- Event handler props: `on` prefix (onClick)
+- Event handler implementations: `handle` prefix (handleClick)
+- Boolean props: `is`, `has`, `can`, `should` prefix
+
+## Conditional Logic
+
+Prefer object literals over if/else chains or switch statements.
+
+// CORRECT
+const THRESHOLDS = [
+{ threshold: 5, result: "hyperarid" },
+{ threshold: 10, result: "arid" },
+{ threshold: Infinity, result: "perhumid" },
+] as const;
+return THRESHOLDS.find(({ threshold }) => value < threshold)?.result ?? null;
+
+// WRONG
+if (value < 5) return "hyperarid";
+if (value < 10) return "arid";
+
+## i18n
+
+- Never hardcode user-facing strings — always use useTranslation
+- When adding new keys: update ALL THREE locale files (en, es, uk)
+- Never restructure existing translation files — only extend
+
+## Styling
+
+Tailwind v4. CSS custom properties for all design tokens — never hardcode
+hex values in components.
+
+## Git Commits
+
+Format: `type(scope): message` — lowercase, present tense, imperative mood
+Types: feat | fix | refactor | chore | docs | perf | style
+
+## What NOT to Do
+
+- Business logic inside components
+- Data fetching in presentational components
+- `any` type or `as` casting
+- Types/enums/interfaces declared outside dedicated files
+- Inline object shapes in function signatures
+- Importing services directly in components
+- Magic strings or numbers
+- Derived data stored in state
+- Hardcoded user-facing strings
+- Adding i18n keys to only one locale
+- Reading process.env or import.meta.env directly
+- Hardcoding hex color values

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/api/services/wikidataService.ts
+++ b/src/api/services/wikidataService.ts
@@ -1,5 +1,6 @@
 import { ENDPOINTS, EXCLUDE_DESCRIPTION_KEYWORDS } from "@/constants";
 import type {
+  TPopulationResult,
   TWikidataCity,
   TWikidataEntitiesResult,
   TWikidataGeoSearchResult,
@@ -13,24 +14,18 @@ import i18n from "i18next";
 const searchCache = new Map<string, TWikidataCity[]>();
 const CACHE_MAX_SIZE = 100;
 
-type TPopulationBinding = {
-  settlement: { value: string };
-  population?: { value: string };
-};
-
-type TPopulationResult = {
-  results: { bindings: TPopulationBinding[] };
-};
+const POP_TIERS = [
+  { threshold: 5_000_000, score: 1_000_000 },
+  { threshold: 1_000_000, score: 100_000 },
+  { threshold: 500_000, score: 50_000 },
+  { threshold: 100_000, score: 10_000 },
+  { threshold: 50_000, score: 5_000 },
+  { threshold: 10_000, score: 1_000 },
+  { threshold: 1_000, score: 100 },
+] as const;
 
 function popTier(pop: number): number {
-  if (pop >= 5_000_000) return 1_000_000;
-  if (pop >= 1_000_000) return 100_000;
-  if (pop >= 500_000) return 50_000;
-  if (pop >= 100_000) return 10_000;
-  if (pop >= 50_000) return 5_000;
-  if (pop >= 10_000) return 1_000;
-  if (pop >= 1_000) return 100;
-  return 0;
+  return POP_TIERS.find(({ threshold }) => pop >= threshold)?.score ?? 0;
 }
 
 function storeCache(key: string, cities: TWikidataCity[]): void {

--- a/src/api/services/wikidataService.ts
+++ b/src/api/services/wikidataService.ts
@@ -10,10 +10,45 @@ import { isValidString, parseWktPoint } from "@/utils";
 import axios from "axios";
 import i18n from "i18next";
 
+const searchCache = new Map<string, TWikidataCity[]>();
+const CACHE_MAX_SIZE = 100;
+
+type TPopulationBinding = {
+  settlement: { value: string };
+  population?: { value: string };
+};
+
+type TPopulationResult = {
+  results: { bindings: TPopulationBinding[] };
+};
+
+function popTier(pop: number): number {
+  if (pop >= 5_000_000) return 1_000_000;
+  if (pop >= 1_000_000) return 100_000;
+  if (pop >= 500_000) return 50_000;
+  if (pop >= 100_000) return 10_000;
+  if (pop >= 50_000) return 5_000;
+  if (pop >= 10_000) return 1_000;
+  if (pop >= 1_000) return 100;
+  return 0;
+}
+
+function storeCache(key: string, cities: TWikidataCity[]): void {
+  if (searchCache.size >= CACHE_MAX_SIZE) {
+    const firstKey = searchCache.keys().next().value;
+    if (firstKey !== undefined) searchCache.delete(firstKey);
+  }
+  searchCache.set(key, cities);
+}
+
 export const WikidataService = {
   async searchCity(query: string): Promise<TWikidataCity[]> {
     const rawLang = i18n.language ?? "en";
     const lang = rawLang === "ua" ? "uk" : rawLang;
+    const cacheKey = `${query}::${lang}`;
+
+    const cached = searchCache.get(cacheKey);
+    if (cached) return cached;
 
     const searchRes = await axios.get<TWikidataSearchResult>(ENDPOINTS.WIKIDATA, {
       params: {
@@ -44,10 +79,29 @@ export const WikidataService = {
       }
     `;
 
-    const sparqlRes = await axios.get<TWikidataSparqlResult>(ENDPOINTS.WIKIDATA_SPARQL as string, {
+    const popQuery = `
+      SELECT ?settlement ?population WHERE {
+        VALUES ?settlement { ${values} }
+        OPTIONAL { ?settlement wdt:P1082 ?population . }
+      }
+    `;
+
+    const coordReq = axios.get<TWikidataSparqlResult>(ENDPOINTS.WIKIDATA_SPARQL as string, {
       params: { query: sparqlQuery, format: "json" },
       headers: { Accept: "application/sparql-results+json" },
     });
+
+    const popReq = axios
+      .get<TPopulationResult>(ENDPOINTS.WIKIDATA_SPARQL, {
+        params: { query: popQuery, format: "json" },
+        headers: { Accept: "application/sparql-results+json" },
+      })
+      .then((r) => r.data)
+      .catch(() => null);
+
+    const popTimeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 1500));
+
+    const [sparqlRes, popData] = await Promise.all([coordReq, Promise.race([popReq, popTimeout])]);
 
     const bindings = sparqlRes.data.results.bindings;
     if (bindings.length === 0) return [];
@@ -55,21 +109,29 @@ export const WikidataService = {
     const itemMap = new Map(items.map((item) => [item.id, item]));
     const lowerQuery = query.toLowerCase();
 
-    const sortedBindings = [...bindings].sort((a, b) => {
-      const idA = a.settlement.value.split("/").pop() ?? "";
-      const idB = b.settlement.value.split("/").pop() ?? "";
+    const coordExtras = new Map<string, { sitelinks: number; statements: number }>();
+    for (const cb of bindings) {
+      const id = cb.settlement.value.split("/").pop() ?? "";
+      coordExtras.set(id, {
+        sitelinks: Number(cb.sitelinks.value),
+        statements: Number(cb.statements.value),
+      });
+    }
+
+    const sortedBindings = [...bindings].sort((ba, bb) => {
+      const idA = ba.settlement.value.split("/").pop() ?? "";
+      const idB = bb.settlement.value.split("/").pop() ?? "";
       const exactA = (itemMap.get(idA)?.label ?? "").toLowerCase() === lowerQuery ? 10000 : 0;
       const exactB = (itemMap.get(idB)?.label ?? "").toLowerCase() === lowerQuery ? 10000 : 0;
-      const scoreA = 3 * Number(a.sitelinks.value) + Number(a.statements.value) + exactA;
-      const scoreB = 3 * Number(b.sitelinks.value) + Number(b.statements.value) + exactB;
+      const scoreA = 3 * Number(ba.sitelinks.value) + Number(ba.statements.value) + exactA;
+      const scoreB = 3 * Number(bb.sitelinks.value) + Number(bb.statements.value) + exactB;
       return scoreB - scoreA;
     });
 
     const seen = new Set<string>();
-    const results: TWikidataCity[] = [];
+    const candidates: TWikidataCity[] = [];
 
     for (const binding of sortedBindings) {
-      if (results.length >= 10) break;
       if (!isValidString(binding.settlement.value)) continue;
 
       const id = binding.settlement.value.split("/").pop() ?? binding.settlement.value;
@@ -87,7 +149,7 @@ export const WikidataService = {
 
       if (EXCLUDE_DESCRIPTION_KEYWORDS.some((k) => lowerDesc.includes(k))) continue;
 
-      results.push({
+      candidates.push({
         id,
         label: String(searchItem?.label ?? id),
         description,
@@ -96,7 +158,46 @@ export const WikidataService = {
       });
     }
 
-    return results;
+    if (candidates.length === 0) return [];
+
+    if (!popData) {
+      const stage1 = candidates.slice(0, 10);
+      storeCache(cacheKey, stage1);
+      return stage1;
+    }
+
+    const popMap = new Map<string, number>();
+    for (const b of popData.results.bindings) {
+      const id = b.settlement.value.split("/").pop() ?? "";
+      if (b.population !== undefined) {
+        const pop = Number(b.population.value);
+        const existing = popMap.get(id);
+        if (existing === undefined || pop > existing) popMap.set(id, pop);
+      }
+    }
+
+    const stage2 = [...candidates]
+      .sort((a, b) => {
+        const exactA = a.label.toLowerCase() === lowerQuery ? 10000 : 0;
+        const exactB = b.label.toLowerCase() === lowerQuery ? 10000 : 0;
+        const extA = coordExtras.get(a.id);
+        const extB = coordExtras.get(b.id);
+        const scoreA =
+          3 * (extA?.sitelinks ?? 0) +
+          (extA?.statements ?? 0) +
+          exactA +
+          popTier(popMap.get(a.id) ?? 0);
+        const scoreB =
+          3 * (extB?.sitelinks ?? 0) +
+          (extB?.statements ?? 0) +
+          exactB +
+          popTier(popMap.get(b.id) ?? 0);
+        return scoreB - scoreA;
+      })
+      .slice(0, 10);
+
+    storeCache(cacheKey, stage2);
+    return stage2;
   },
 
   async findNearestCityByCoordinates(lat: number, lng: number): Promise<TWikidataCity | null> {

--- a/src/api/services/wikidataService.ts
+++ b/src/api/services/wikidataService.ts
@@ -241,9 +241,9 @@ export const WikidataService = {
       const entity = entities[id];
       if (!entity) continue;
 
-      const label = entity.labels?.[lang]?.value ?? entity.labels?.en?.value ?? "";
+      const label = entity.labels?.[lang]?.value ?? entity.labels?.["en"]?.value ?? "";
       const description =
-        entity.descriptions?.[lang]?.value ?? entity.descriptions?.en?.value ?? "";
+        entity.descriptions?.[lang]?.value ?? entity.descriptions?.["en"]?.value ?? "";
 
       return {
         id,

--- a/src/api/services/worldClimService.ts
+++ b/src/api/services/worldClimService.ts
@@ -1,7 +1,7 @@
-import type { TClimatePeriod } from "@/constants";
 import { WORLDCLIM_BASE_URL } from "@/constants";
 import type {
   TCellSize,
+  TClimatePeriod,
   TRawAvgValueResponse,
   TRawPixelValueResponse,
   TVariable,

--- a/src/components/CompareStatsGrid/CompareStatsGrid.type.ts
+++ b/src/components/CompareStatsGrid/CompareStatsGrid.type.ts
@@ -1,4 +1,4 @@
-import type { TCompareStats } from "@/pages/ClimateComparison/ClimateComparison.util";
+import type { TCompareStats } from "@/pages/ClimateComparison/ClimateComparison.type";
 
 export type TCompareStatsGridProps = {
   labelA: string;

--- a/src/components/TempPrecipChart/TempPrecipChart.tsx
+++ b/src/components/TempPrecipChart/TempPrecipChart.tsx
@@ -3,13 +3,13 @@ import { CLIMATE_PERIOD_LABELS, DATASETS } from "@/constants";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ModeToggle } from "./components/ModeToggle";
-import { useTempPrecipChart } from "./hooks/useTempPrecipChart";
+import { useTempPrecipChart } from "./hooks";
 import { CalendarIcon, DatabaseIcon } from "./icons";
 import { StandardClimateChart } from "./StandardClimateChart";
 import type { TChartMode, TTempPrecipChartProps, TVisibleSeries } from "./TempPrecipChart.type";
+import { WalterLiethChart } from "./WalterLiethChart";
 import { WLCitiesLayout } from "./WLCitiesLayout";
 import { WLPeriodsLayout } from "./WLPeriodsLayout";
-import { WalterLiethChart } from "./WalterLiethChart";
 
 const DEFAULT_VISIBLE: TVisibleSeries = { tmax: true, tmin: true, tavg: false, prec: true };
 

--- a/src/constants/sidebar.constant.ts
+++ b/src/constants/sidebar.constant.ts
@@ -18,4 +18,21 @@ export const SIDEBAR_PARAMS = {
   BBOX_EAST: "east",
   COMPARE_CITY_A: "cityA",
   COMPARE_CITY_B: "cityB",
+
+  // * shareable URL params
+  CITY: "city",
+  LAT: "lat",
+  LNG: "lng",
+  LAT_A: "latA",
+  LNG_A: "lngA",
+  LAT_B: "latB",
+  LNG_B: "lngB",
+  PERIOD: "period",
+  YEAR: "year",
+  PERIOD_A: "period1",
+  PERIOD_B: "period2",
+  YEAR_A: "year1",
+  YEAR_B: "year2",
+  VAR: "var",
+  POLYGON: "polygon",
 } as const;

--- a/src/hooks/data/useGetCompareData.ts
+++ b/src/hooks/data/useGetCompareData.ts
@@ -1,9 +1,9 @@
 import { WorldClimService } from "@/api";
-import type { TClimatePeriod } from "@/constants";
 import { DATASETS, WEATHER_VARIABLES } from "@/constants";
 import { useFiltersStore } from "@/stores";
 import type {
   TCellSize,
+  TClimatePeriod,
   TCompareData,
   TMonthlyTemperature,
   TUseGetCompareDataReturn,

--- a/src/hooks/data/useGetComparePeriods.ts
+++ b/src/hooks/data/useGetComparePeriods.ts
@@ -1,7 +1,12 @@
 import { WorldClimService } from "@/api";
 import { DATASETS, WEATHER_VARIABLES } from "@/constants";
-import type { TClimatePeriod } from "@/constants/worldclim.constant";
-import type { TCellSize, TComparePeriods, TDataset, TUseGetComparePeriodsReturn } from "@/types";
+import type {
+  TCellSize,
+  TClimatePeriod,
+  TComparePeriods,
+  TDataset,
+  TUseGetComparePeriodsReturn,
+} from "@/types";
 import { buildMonthlyTemperaturesFromPointValues } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 import { fetchCityData } from "./useGetCompareData";

--- a/src/hooks/data/useGetHeatmapData.ts
+++ b/src/hooks/data/useGetHeatmapData.ts
@@ -1,6 +1,5 @@
 import { WorldClimService } from "@/api";
-import type { TClimatePeriod } from "@/constants";
-import type { TBbox, TCellSize, THeatmapResult, TVariable } from "@/types";
+import type { TBbox, TCellSize, TClimatePeriod, THeatmapResult, TVariable } from "@/types";
 import { groupAvgBindings, groupPixelBindings } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 

--- a/src/hooks/data/useGetHeatmapPolygonData.ts
+++ b/src/hooks/data/useGetHeatmapPolygonData.ts
@@ -1,6 +1,5 @@
-import { WorldClimService } from "@/api/services/worldClimService";
-import type { TClimatePeriod } from "@/constants";
-import type { TCellSize, TPolygonResult, TVariable } from "@/types";
+import { WorldClimService } from "@/api";
+import type { TCellSize, TClimatePeriod, TPolygonResult, TVariable } from "@/types";
 import { groupAvgBindings, groupPixelBindings } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 

--- a/src/hooks/data/useGetRegionalProfile.ts
+++ b/src/hooks/data/useGetRegionalProfile.ts
@@ -1,6 +1,11 @@
-import { WorldClimService } from "@/api/services/worldClimService";
-import type { TClimatePeriod } from "@/constants";
-import type { TBbox, TCellSize, TProfileResult, TWorldClimAvgBoxBinding } from "@/types";
+import { WorldClimService } from "@/api";
+import type {
+  TBbox,
+  TCellSize,
+  TClimatePeriod,
+  TProfileResult,
+  TWorldClimAvgBoxBinding,
+} from "@/types";
 import { groupAvgBindings } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 

--- a/src/pages/ClimateComparison/ClimateComparison.type.ts
+++ b/src/pages/ClimateComparison/ClimateComparison.type.ts
@@ -1,0 +1,32 @@
+export type TCompareStats = {
+  avgTmax: number;
+  avgTmin: number;
+  totalPrec: number;
+  aridMonths: number;
+  martonneIndex: number | null;
+};
+
+export type TCompareChartPoint = {
+  monthName: string;
+  tmaxA: number;
+  tminA: number;
+  tavgA: number;
+  precA: number;
+  tmaxB: number;
+  tminB: number;
+  tavgB: number;
+  precB: number;
+};
+
+export type TDiffStats = {
+  warmerCity: "A" | "B" | "tie";
+  tmaxDiff: number;
+  moreRainCity: "A" | "B" | "tie";
+  precDiff: number;
+  hottestMonthName: string;
+  hottestTempA: number;
+  hottestTempB: number;
+  coldestMonthName: string;
+  coldestTempA: number;
+  coldestTempB: number;
+};

--- a/src/pages/ClimateComparison/ClimateComparison.util.ts
+++ b/src/pages/ClimateComparison/ClimateComparison.util.ts
@@ -1,37 +1,7 @@
 import type { TMonthlyTemperature } from "@/types";
+import type { TCompareChartPoint, TCompareStats, TDiffStats } from "./ClimateComparison.type";
 
-export type TCompareStats = {
-  avgTmax: number;
-  avgTmin: number;
-  totalPrec: number;
-  aridMonths: number;
-  martonneIndex: number | null;
-};
-
-export type TCompareChartPoint = {
-  monthName: string;
-  tmaxA: number;
-  tminA: number;
-  tavgA: number;
-  precA: number;
-  tmaxB: number;
-  tminB: number;
-  tavgB: number;
-  precB: number;
-};
-
-export type TDiffStats = {
-  warmerCity: "A" | "B" | "tie";
-  tmaxDiff: number;
-  moreRainCity: "A" | "B" | "tie";
-  precDiff: number;
-  hottestMonthName: string;
-  hottestTempA: number;
-  hottestTempB: number;
-  coldestMonthName: string;
-  coldestTempA: number;
-  coldestTempB: number;
-};
+export type { TCompareChartPoint, TCompareStats, TDiffStats };
 
 export function computeCompareStats(data: TMonthlyTemperature[]): TCompareStats {
   const count = data.length;

--- a/src/pages/ClimateComparison/index.ts
+++ b/src/pages/ClimateComparison/index.ts
@@ -1,1 +1,3 @@
-export { ClimateComparison } from "./ClimateComparison";
+export * from "./ClimateComparison.constant";
+export * from "./ClimateComparison.type";
+export * from "./ClimateComparison.util";

--- a/src/pages/ClimateStatistics/ClimateStatistics.tsx
+++ b/src/pages/ClimateStatistics/ClimateStatistics.tsx
@@ -1,5 +1,5 @@
 import type { TChartSubtitle } from "@/components/TempPrecipChart/TempPrecipChart.type";
-import { DATASETS } from "@/constants";
+import { CLIMATE_PERIOD_LABELS, DATASETS, SIDEBAR_PARAMS, VARIABLE_LABELS } from "@/constants";
 import {
   useGeolocation,
   useGetAltitude,
@@ -10,10 +10,21 @@ import {
 } from "@/hooks";
 import { useFiltersStore } from "@/stores";
 import type { TWikidataCity } from "@/types";
+import {
+  encodeMonths,
+  encodeVars,
+  parseCellSize,
+  parseCoord,
+  parseDataset,
+  parseMonths,
+  parsePeriod,
+  parseVars,
+  parseYear,
+} from "@/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
-import { formatCoordinate, toCityQueryParam } from "./ClimateStatistics.util";
+import { formatCoordinate } from "./ClimateStatistics.util";
 import { ClimateStatisticsView } from "./ClimateStatisticsView";
 
 function resolveCityName(city: TWikidataCity): string {
@@ -39,26 +50,128 @@ export function ClimateStatistics() {
       ? { dataset: DATASETS.CLIMATE, climatePeriod }
       : { dataset: DATASETS.WEATHER, weatherYear };
 
-  const selectedCityInUrl = useMemo(
-    () => toCityQueryParam(selectedCity.label),
-    [selectedCity.label],
-  );
-
+  // Restore city and filters from URL once on mount
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (searchParams.get("city") === selectedCityInUrl) {
-      return;
+    const lat = parseCoord(searchParams.get(SIDEBAR_PARAMS.LAT));
+    const lng = parseCoord(searchParams.get(SIDEBAR_PARAMS.LNG));
+    const cityLabel = searchParams.get(SIDEBAR_PARAMS.CITY);
+
+    if (lat !== null && lng !== null) {
+      const urlCity: TWikidataCity = {
+        id: `url:${lat},${lng}`,
+        label: cityLabel ?? `${lat}, ${lng}`,
+        description: "",
+        lat,
+        lng,
+      };
+      selectCity(urlCity);
+      if (cityLabel) setChartCityName(cityLabel);
     }
 
+    const store = useFiltersStore.getState();
+    const ds = parseDataset(searchParams.get(SIDEBAR_PARAMS.DATASET));
+    if (ds !== null) store.actions.setDataset(ds);
+
+    const period = parsePeriod(searchParams.get(SIDEBAR_PARAMS.PERIOD));
+    if (period !== null) store.actions.setClimatePeriod(period);
+
+    const year = parseYear(searchParams.get(SIDEBAR_PARAMS.YEAR));
+    if (year !== null) store.actions.setWeatherYear(year);
+
+    const vars = parseVars(searchParams.get(SIDEBAR_PARAMS.VAR));
+    if (vars !== null) store.actions.setVariables(vars);
+
+    const grid = parseCellSize(searchParams.get(SIDEBAR_PARAMS.GRID));
+    if (grid !== null) store.actions.setGridSize(grid);
+
+    const monthFilter = parseMonths(searchParams.get(SIDEBAR_PARAMS.MONTHS));
+    if (monthFilter !== null) store.actions.setMonths(monthFilter);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Sync all shareable state → URL (replace, no history pollution)
+  const cityLabel = selectedCity.label.trim();
+  const latStr = selectedCity.lat.toFixed(4);
+  const lngStr = selectedCity.lng.toFixed(4);
+  const varsStr = useMemo(() => encodeVars(variables), [variables]);
+  const monthsStr = useMemo(() => encodeMonths(months), [months]);
+
+  useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);
-    nextParams.set("city", selectedCityInUrl);
-    setSearchParams(nextParams, { replace: true });
-  }, [searchParams, selectedCityInUrl, setSearchParams]);
+    let changed = false;
+
+    function maybeSet(key: string, value: string) {
+      if (nextParams.get(key) !== value) {
+        nextParams.set(key, value);
+        changed = true;
+      }
+    }
+    function maybeDelete(key: string) {
+      if (nextParams.has(key)) {
+        nextParams.delete(key);
+        changed = true;
+      }
+    }
+
+    maybeSet(SIDEBAR_PARAMS.CITY, cityLabel);
+    maybeSet(SIDEBAR_PARAMS.LAT, latStr);
+    maybeSet(SIDEBAR_PARAMS.LNG, lngStr);
+    maybeSet(SIDEBAR_PARAMS.DATASET, dataset);
+    maybeSet(SIDEBAR_PARAMS.VAR, varsStr);
+    maybeSet(SIDEBAR_PARAMS.GRID, gridSize);
+    maybeSet(SIDEBAR_PARAMS.MONTHS, monthsStr);
+
+    if (dataset === DATASETS.CLIMATE) {
+      maybeSet(SIDEBAR_PARAMS.PERIOD, climatePeriod);
+      maybeDelete(SIDEBAR_PARAMS.YEAR);
+    } else {
+      maybeSet(SIDEBAR_PARAMS.YEAR, String(weatherYear));
+      maybeDelete(SIDEBAR_PARAMS.PERIOD);
+    }
+
+    if (changed) setSearchParams(nextParams, { replace: true });
+  }, [
+    cityLabel,
+    latStr,
+    lngStr,
+    dataset,
+    climatePeriod,
+    weatherYear,
+    varsStr,
+    gridSize,
+    monthsStr,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  // Document title
+  useEffect(() => {
+    const cityStr = chartCityName || cityLabel;
+    if (!cityStr) {
+      document.title = "City Climate | Climatica";
+      return;
+    }
+    const varLabel = variables[0] ? (VARIABLE_LABELS[variables[0]] ?? variables[0]) : "";
+    const periodStr =
+      dataset === DATASETS.CLIMATE
+        ? (CLIMATE_PERIOD_LABELS[climatePeriod] ?? climatePeriod)
+        : String(weatherYear);
+    document.title = `${cityStr} · ${varLabel} ${periodStr} | Climatica`;
+  }, [chartCityName, cityLabel, variables, dataset, climatePeriod, weatherYear]);
 
   function handleCitySelect(city: TWikidataCity) {
     clearLocationError();
     const name = resolveCityName(city);
     if (name) setChartCityName(name);
     selectCity(city);
+
+    // push new history entry when user explicitly selects a city
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(SIDEBAR_PARAMS.CITY, city.label.trim());
+    nextParams.set(SIDEBAR_PARAMS.LAT, city.lat.toFixed(4));
+    nextParams.set(SIDEBAR_PARAMS.LNG, city.lng.toFixed(4));
+    setSearchParams(nextParams, { replace: false });
   }
 
   function handleLocate() {
@@ -84,7 +197,6 @@ export function ClimateStatistics() {
       lng,
     };
 
-    /** update coordinates immediately so climate fetch starts without waiting for Wikidata */
     selectCity(provisionalCity);
 
     try {
@@ -102,7 +214,7 @@ export function ClimateStatistics() {
         lng,
       });
     } catch {
-      /** keep provisional map label if reverse lookup fails */
+      // keep provisional map label if reverse lookup fails
     }
   }
 

--- a/src/pages/ClimateStatistics/ClimateStatistics.type.ts
+++ b/src/pages/ClimateStatistics/ClimateStatistics.type.ts
@@ -36,3 +36,9 @@ export type TStatCardProps = {
   unit?: string;
   tooltip?: string;
 };
+
+export type TClimateStats = {
+  avgTmax: string;
+  avgTmin: string;
+  totalPrec: string;
+};

--- a/src/pages/ClimateStatistics/ClimateStatistics.util.ts
+++ b/src/pages/ClimateStatistics/ClimateStatistics.util.ts
@@ -1,4 +1,7 @@
 import type { TMonthlyTemperature } from "@/types";
+import type { TClimateStats } from "./ClimateStatistics.type";
+
+export type { TClimateStats };
 
 export function toCityQueryParam(cityLabel: string) {
   return cityLabel.trim().toLowerCase();
@@ -7,12 +10,6 @@ export function toCityQueryParam(cityLabel: string) {
 export function formatCoordinate(value: number) {
   return value.toFixed(4);
 }
-
-export type TClimateStats = {
-  avgTmax: string;
-  avgTmin: string;
-  totalPrec: string;
-};
 
 export function computeClimateStats(
   data: TMonthlyTemperature[],

--- a/src/pages/CompareCities/CompareCities.tsx
+++ b/src/pages/CompareCities/CompareCities.tsx
@@ -2,29 +2,147 @@ import type { TChartSubtitle } from "@/components/TempPrecipChart";
 import { DATASETS, SIDEBAR_PARAMS } from "@/constants";
 import { useGetAltitude, useGetCompareData, usePersistedComparisonCities } from "@/hooks";
 import { useFiltersStore } from "@/stores";
-import { useEffect } from "react";
+import type { TWikidataCity } from "@/types";
+import {
+  encodeVars,
+  parseCellSize,
+  parseCoord,
+  parseDataset,
+  parsePeriod,
+  parseVars,
+  parseYear,
+} from "@/utils";
+import { useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { CompareCitiesView } from "./CompareCitiesView";
 
+function cityFromUrl(
+  latRaw: string | null,
+  lngRaw: string | null,
+  labelRaw: string | null,
+): TWikidataCity | null {
+  const lat = parseCoord(latRaw);
+  const lng = parseCoord(lngRaw);
+  if (lat === null || lng === null) return null;
+  return {
+    id: `url:${lat},${lng}`,
+    label: labelRaw ?? `${lat}, ${lng}`,
+    description: "",
+    lat,
+    lng,
+  };
+}
+
 export function CompareCities() {
   const { cityA, cityB, selectCityA, selectCityB } = usePersistedComparisonCities();
-  const { gridSize, dataset, climatePeriod, weatherYear, months } = useFiltersStore();
+  const { gridSize, dataset, climatePeriod, weatherYear, months, variables } = useFiltersStore();
   const selectedMonths = Array.isArray(months) ? months : null;
   const [searchParams, setSearchParams] = useSearchParams();
+
+  // Restore cities and filters from URL once on mount
+  useEffect(() => {
+    const urlCityA = cityFromUrl(
+      searchParams.get(SIDEBAR_PARAMS.LAT_A),
+      searchParams.get(SIDEBAR_PARAMS.LNG_A),
+      searchParams.get(SIDEBAR_PARAMS.COMPARE_CITY_A),
+    );
+    if (urlCityA) selectCityA(urlCityA);
+
+    const urlCityB = cityFromUrl(
+      searchParams.get(SIDEBAR_PARAMS.LAT_B),
+      searchParams.get(SIDEBAR_PARAMS.LNG_B),
+      searchParams.get(SIDEBAR_PARAMS.COMPARE_CITY_B),
+    );
+    if (urlCityB) selectCityB(urlCityB);
+
+    const store = useFiltersStore.getState();
+
+    const ds = parseDataset(searchParams.get(SIDEBAR_PARAMS.DATASET));
+    if (ds !== null) store.actions.setDataset(ds);
+
+    const period = parsePeriod(searchParams.get(SIDEBAR_PARAMS.PERIOD));
+    if (period !== null) store.actions.setClimatePeriod(period);
+
+    const year = parseYear(searchParams.get(SIDEBAR_PARAMS.YEAR));
+    if (year !== null) store.actions.setWeatherYear(year);
+
+    const vars = parseVars(searchParams.get(SIDEBAR_PARAMS.VAR));
+    if (vars !== null) store.actions.setVariables(vars);
+
+    const grid = parseCellSize(searchParams.get(SIDEBAR_PARAMS.GRID));
+    if (grid !== null) store.actions.setGridSize(grid);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync all shareable state → URL (replace)
+  const varsStr = useMemo(() => encodeVars(variables), [variables]);
 
   useEffect(() => {
     const nextParams = new URLSearchParams(searchParams);
     let changed = false;
-    if (nextParams.get(SIDEBAR_PARAMS.COMPARE_CITY_A) !== cityA.label) {
-      nextParams.set(SIDEBAR_PARAMS.COMPARE_CITY_A, cityA.label);
-      changed = true;
+
+    function maybeSet(key: string, value: string) {
+      if (nextParams.get(key) !== value) {
+        nextParams.set(key, value);
+        changed = true;
+      }
     }
-    if (nextParams.get(SIDEBAR_PARAMS.COMPARE_CITY_B) !== cityB.label) {
-      nextParams.set(SIDEBAR_PARAMS.COMPARE_CITY_B, cityB.label);
-      changed = true;
+    function maybeDelete(key: string) {
+      if (nextParams.has(key)) {
+        nextParams.delete(key);
+        changed = true;
+      }
     }
+
+    maybeSet(SIDEBAR_PARAMS.COMPARE_CITY_A, cityA.label);
+    maybeSet(SIDEBAR_PARAMS.LAT_A, cityA.lat.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.LNG_A, cityA.lng.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.COMPARE_CITY_B, cityB.label);
+    maybeSet(SIDEBAR_PARAMS.LAT_B, cityB.lat.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.LNG_B, cityB.lng.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.DATASET, dataset);
+    maybeSet(SIDEBAR_PARAMS.VAR, varsStr);
+    maybeSet(SIDEBAR_PARAMS.GRID, gridSize);
+
+    if (dataset === DATASETS.CLIMATE) {
+      maybeSet(SIDEBAR_PARAMS.PERIOD, climatePeriod);
+      maybeDelete(SIDEBAR_PARAMS.YEAR);
+    } else {
+      maybeSet(SIDEBAR_PARAMS.YEAR, String(weatherYear));
+      maybeDelete(SIDEBAR_PARAMS.PERIOD);
+    }
+
     if (changed) setSearchParams(nextParams, { replace: true });
-  }, [cityA.label, cityB.label]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    cityA.label,
+    cityA.lat,
+    cityA.lng,
+    cityB.label,
+    cityB.lat,
+    cityB.lng,
+    dataset,
+    climatePeriod,
+    weatherYear,
+    varsStr,
+    gridSize,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  // Document title
+  useEffect(() => {
+    const labelA = cityA.label;
+    const labelB = cityB.label;
+    const bothValid =
+      labelA &&
+      labelB &&
+      !labelA.startsWith("url:") &&
+      !labelB.startsWith("url:") &&
+      !/^Q\d+$/.test(labelA) &&
+      !/^Q\d+$/.test(labelB);
+    document.title = bothValid
+      ? `${labelA} vs ${labelB} | Climatica`
+      : "Compare Cities | Climatica";
+  }, [cityA.label, cityB.label]);
 
   const subtitle: TChartSubtitle =
     dataset === DATASETS.CLIMATE ? { dataset, climatePeriod } : { dataset, weatherYear };
@@ -39,6 +157,24 @@ export function CompareCities() {
   const { data: altitudeA = null } = useGetAltitude(cityA.lat, cityA.lng, gridSize);
   const { data: altitudeB = null } = useGetAltitude(cityB.lat, cityB.lng, gridSize);
 
+  function handleCityASelect(city: TWikidataCity) {
+    selectCityA(city);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(SIDEBAR_PARAMS.COMPARE_CITY_A, city.label);
+    nextParams.set(SIDEBAR_PARAMS.LAT_A, city.lat.toFixed(4));
+    nextParams.set(SIDEBAR_PARAMS.LNG_A, city.lng.toFixed(4));
+    setSearchParams(nextParams, { replace: false });
+  }
+
+  function handleCityBSelect(city: TWikidataCity) {
+    selectCityB(city);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(SIDEBAR_PARAMS.COMPARE_CITY_B, city.label);
+    nextParams.set(SIDEBAR_PARAMS.LAT_B, city.lat.toFixed(4));
+    nextParams.set(SIDEBAR_PARAMS.LNG_B, city.lng.toFixed(4));
+    setSearchParams(nextParams, { replace: false });
+  }
+
   return (
     <CompareCitiesView
       cityA={cityA}
@@ -52,8 +188,8 @@ export function CompareCities() {
       error={error}
       altitudeA={altitudeA}
       altitudeB={altitudeB}
-      onCityASelect={selectCityA}
-      onCityBSelect={selectCityB}
+      onCityASelect={handleCityASelect}
+      onCityBSelect={handleCityBSelect}
     />
   );
 }

--- a/src/pages/ComparePeriods/ComparePeriods.tsx
+++ b/src/pages/ComparePeriods/ComparePeriods.tsx
@@ -1,5 +1,12 @@
-import { CLIMATE_PERIODS, WEATHER_MAX_YEAR, WEATHER_MIN_YEAR } from "@/constants";
-import type { TClimatePeriod } from "@/constants/worldclim.constant";
+import {
+  CLIMATE_PERIOD_LABELS,
+  CLIMATE_PERIODS,
+  DATASETS,
+  SIDEBAR_PARAMS,
+  VARIABLE_LABELS,
+  WEATHER_MAX_YEAR,
+  WEATHER_MIN_YEAR,
+} from "@/constants";
 import {
   useGeolocation,
   useGetAltitude,
@@ -7,21 +14,156 @@ import {
   usePersistedComparisonCities,
 } from "@/hooks";
 import { useFiltersStore } from "@/stores";
-import { useState } from "react";
+import type { TClimatePeriod, TWikidataCity } from "@/types";
+import {
+  encodeMonths,
+  encodeVars,
+  parseCellSize,
+  parseCoord,
+  parseDataset,
+  parsePeriod,
+  parseVars,
+  parseYear,
+} from "@/utils";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
 import { ComparePeriodsView } from "./ComparePeriodsView";
+
+function resolvePeriodFromUrl(raw: string | null, fallback: TClimatePeriod): TClimatePeriod {
+  return parsePeriod(raw) ?? fallback;
+}
+
+function resolveYearFromUrl(raw: string | null, fallback: number): number {
+  return parseYear(raw) ?? fallback;
+}
 
 export function ComparePeriods() {
   const { t } = useTranslation();
   const { cityA, selectCityA } = usePersistedComparisonCities();
-  const { gridSize, dataset, months } = useFiltersStore();
+  const { gridSize, dataset, months, variables } = useFiltersStore();
   const { locate, isLocating, locationError, clearLocationError } = useGeolocation();
   const selectedMonths = Array.isArray(months) ? months : null;
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const [climatePeriodA, setClimatePeriodA] = useState<TClimatePeriod>(CLIMATE_PERIODS.C1970_2000);
-  const [climatePeriodB, setClimatePeriodB] = useState<TClimatePeriod>(CLIMATE_PERIODS.C1991_2020);
-  const [yearA, setYearA] = useState<number>(WEATHER_MIN_YEAR);
-  const [yearB, setYearB] = useState<number>(WEATHER_MAX_YEAR);
+  // Lazy initial values from URL (read once at mount)
+  const [climatePeriodA, setClimatePeriodA] = useState<TClimatePeriod>(() =>
+    resolvePeriodFromUrl(searchParams.get(SIDEBAR_PARAMS.PERIOD_A), CLIMATE_PERIODS.C1970_2000),
+  );
+  const [climatePeriodB, setClimatePeriodB] = useState<TClimatePeriod>(() =>
+    resolvePeriodFromUrl(searchParams.get(SIDEBAR_PARAMS.PERIOD_B), CLIMATE_PERIODS.C1991_2020),
+  );
+  const [yearA, setYearA] = useState<number>(() =>
+    resolveYearFromUrl(searchParams.get(SIDEBAR_PARAMS.YEAR_A), WEATHER_MIN_YEAR),
+  );
+  const [yearB, setYearB] = useState<number>(() =>
+    resolveYearFromUrl(searchParams.get(SIDEBAR_PARAMS.YEAR_B), WEATHER_MAX_YEAR),
+  );
+
+  // Restore city and global filters from URL once on mount
+  useEffect(() => {
+    const lat = parseCoord(searchParams.get(SIDEBAR_PARAMS.LAT));
+    const lng = parseCoord(searchParams.get(SIDEBAR_PARAMS.LNG));
+    const cityLabel = searchParams.get(SIDEBAR_PARAMS.CITY);
+
+    if (lat !== null && lng !== null) {
+      const urlCity: TWikidataCity = {
+        id: `url:${lat},${lng}`,
+        label: cityLabel ?? `${lat}, ${lng}`,
+        description: "",
+        lat,
+        lng,
+      };
+      selectCityA(urlCity);
+    }
+
+    const store = useFiltersStore.getState();
+
+    const ds = parseDataset(searchParams.get(SIDEBAR_PARAMS.DATASET));
+    if (ds !== null) store.actions.setDataset(ds);
+
+    const vars = parseVars(searchParams.get(SIDEBAR_PARAMS.VAR));
+    if (vars !== null) store.actions.setVariables(vars);
+
+    const grid = parseCellSize(searchParams.get(SIDEBAR_PARAMS.GRID));
+    if (grid !== null) store.actions.setGridSize(grid);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync all shareable state → URL (replace)
+  const varsStr = useMemo(() => encodeVars(variables), [variables]);
+  const monthsStr = useMemo(() => encodeMonths(months), [months]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(searchParams);
+    let changed = false;
+
+    function maybeSet(key: string, value: string) {
+      if (nextParams.get(key) !== value) {
+        nextParams.set(key, value);
+        changed = true;
+      }
+    }
+    function maybeDelete(key: string) {
+      if (nextParams.has(key)) {
+        nextParams.delete(key);
+        changed = true;
+      }
+    }
+
+    maybeSet(SIDEBAR_PARAMS.CITY, cityA.label.trim());
+    maybeSet(SIDEBAR_PARAMS.LAT, cityA.lat.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.LNG, cityA.lng.toFixed(4));
+    maybeSet(SIDEBAR_PARAMS.DATASET, dataset);
+    maybeSet(SIDEBAR_PARAMS.VAR, varsStr);
+    maybeSet(SIDEBAR_PARAMS.GRID, gridSize);
+    maybeSet(SIDEBAR_PARAMS.MONTHS, monthsStr);
+
+    if (dataset === DATASETS.CLIMATE) {
+      maybeSet(SIDEBAR_PARAMS.PERIOD_A, climatePeriodA);
+      maybeSet(SIDEBAR_PARAMS.PERIOD_B, climatePeriodB);
+      maybeDelete(SIDEBAR_PARAMS.YEAR_A);
+      maybeDelete(SIDEBAR_PARAMS.YEAR_B);
+    } else {
+      maybeSet(SIDEBAR_PARAMS.YEAR_A, String(yearA));
+      maybeSet(SIDEBAR_PARAMS.YEAR_B, String(yearB));
+      maybeDelete(SIDEBAR_PARAMS.PERIOD_A);
+      maybeDelete(SIDEBAR_PARAMS.PERIOD_B);
+    }
+
+    if (changed) setSearchParams(nextParams, { replace: true });
+  }, [
+    cityA.label,
+    cityA.lat,
+    cityA.lng,
+    dataset,
+    climatePeriodA,
+    climatePeriodB,
+    yearA,
+    yearB,
+    varsStr,
+    gridSize,
+    monthsStr,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  // Document title
+  useEffect(() => {
+    const cityLabel = cityA.label;
+    const validCity = cityLabel && !cityLabel.startsWith("url:") && !/^Q\d+$/.test(cityLabel);
+    if (!validCity) {
+      document.title = "Compare Periods | Climatica";
+      return;
+    }
+    const varLabel = variables[0] ? (VARIABLE_LABELS[variables[0]] ?? variables[0]) : "";
+    if (dataset === DATASETS.CLIMATE) {
+      const labelA = CLIMATE_PERIOD_LABELS[climatePeriodA] ?? climatePeriodA;
+      const labelB = CLIMATE_PERIOD_LABELS[climatePeriodB] ?? climatePeriodB;
+      document.title = `${cityLabel} · ${varLabel} ${labelA} vs ${labelB} | Climatica`;
+    } else {
+      document.title = `${cityLabel} · ${varLabel} ${yearA} vs ${yearB} | Climatica`;
+    }
+  }, [cityA.label, dataset, climatePeriodA, climatePeriodB, yearA, yearB, variables]);
 
   const { dataA, dataB, isLoading, error } = useGetComparePeriods(
     cityA.lat,
@@ -38,6 +180,15 @@ export function ComparePeriods() {
 
   function handleLocate() {
     locate(selectCityA);
+  }
+
+  function handleCitySelect(city: TWikidataCity) {
+    selectCityA(city);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set(SIDEBAR_PARAMS.CITY, city.label.trim());
+    nextParams.set(SIDEBAR_PARAMS.LAT, city.lat.toFixed(4));
+    nextParams.set(SIDEBAR_PARAMS.LNG, city.lng.toFixed(4));
+    setSearchParams(nextParams, { replace: false });
   }
 
   const resolvedLocationError = locationError !== null ? t(locationError) : null;
@@ -59,7 +210,7 @@ export function ComparePeriods() {
       isLocating={isLocating}
       error={error}
       locationError={resolvedLocationError}
-      onCitySelect={selectCityA}
+      onCitySelect={handleCitySelect}
       onLocate={handleLocate}
       onClearLocationError={clearLocationError}
       onClimatePeriodAChange={setClimatePeriodA}

--- a/src/pages/ComparePeriods/ComparePeriodsView.tsx
+++ b/src/pages/ComparePeriods/ComparePeriodsView.tsx
@@ -10,9 +10,9 @@ import {
 } from "@/components";
 import { Dropdown, PageWrapper } from "@/components/UI";
 import { CELL_SIZE_OPTIONS, CLIMATE_PERIOD_LABELS, CLIMATE_PERIODS, DATASETS } from "@/constants";
-import type { TClimatePeriod } from "@/constants/worldclim.constant";
 import { CLIMATE_COMPARISON_COLORS } from "@/pages/ClimateComparison/ClimateComparison.constant";
 import { computeCompareStats } from "@/pages/ClimateComparison/ClimateComparison.util";
+import type { TClimatePeriod } from "@/types";
 import { useTranslation } from "react-i18next";
 import type { TClimatePeriodRowProps, TComparePeriodsViewProps } from "./ComparePeriods.type";
 

--- a/src/pages/HeatMap/HeatMap.tsx
+++ b/src/pages/HeatMap/HeatMap.tsx
@@ -1,4 +1,4 @@
-import { CLIMATE_PERIOD_LABELS, DATASETS, SIDEBAR_PARAMS } from "@/constants";
+import { CLIMATE_PERIOD_LABELS, DATASETS, SIDEBAR_PARAMS, VARIABLE_LABELS } from "@/constants";
 import {
   useGeolocation,
   useGetHeatmapData,
@@ -7,18 +7,33 @@ import {
 } from "@/hooks";
 import { useFiltersStore } from "@/stores";
 import type { TBbox, TColorScale, TWikidataCity } from "@/types";
-import { useState } from "react";
+import {
+  encodeVars,
+  parseCellSize,
+  parseDataset,
+  parsePeriod,
+  parseVars,
+  parseYear,
+} from "@/utils";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import type { TDrawMode, TMapTarget, TPolygon } from "./HeatMap.type";
-import { computeRegionalProfile, polygonToWkt } from "./HeatMap.util";
+import { computeRegionalProfile, polygonToWkt, wktToPolygon } from "./HeatMap.util";
 import { HeatMapView } from "./HeatMapView";
 
 export function HeatMap() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [drawMode, setDrawMode] = useState<TDrawMode>("none");
-  const [polygon, setPolygon] = useState<TPolygon | null>(null);
+
+  // Restore polygon from URL on mount; lazy initializer reads searchParams once
+  // URLSearchParams.get() already URL-decodes, so no extra decodeURIComponent needed
+  const [polygon, setPolygon] = useState<TPolygon | null>(() => {
+    const raw = searchParams.get(SIDEBAR_PARAMS.POLYGON);
+    return raw !== null ? wktToPolygon(raw) : null;
+  });
+
   const [mapTarget, setMapTarget] = useState<TMapTarget | null>(null);
   const { locate, isLocating, locationError, clearLocationError } = useGeolocation();
 
@@ -37,7 +52,7 @@ export function HeatMap() {
   const activeVariable = variables[0] ?? "tmax";
   const colorScale: TColorScale = activeVariable === "prec" ? "precipitation" : "temperature";
 
-  // Bbox from URL search params — null until user draws
+  // Bbox from URL search params
   const northRaw = searchParams.get(SIDEBAR_PARAMS.BBOX_NORTH);
   const southRaw = searchParams.get(SIDEBAR_PARAMS.BBOX_SOUTH);
   const westRaw = searchParams.get(SIDEBAR_PARAMS.BBOX_WEST);
@@ -51,6 +66,79 @@ export function HeatMap() {
           east: Number(eastRaw),
         }
       : null;
+
+  // Restore global filters from URL once on mount
+  useEffect(() => {
+    const store = useFiltersStore.getState();
+
+    const ds = parseDataset(searchParams.get(SIDEBAR_PARAMS.DATASET));
+    if (ds !== null) store.actions.setDataset(ds);
+
+    const period = parsePeriod(searchParams.get(SIDEBAR_PARAMS.PERIOD));
+    if (period !== null) store.actions.setClimatePeriod(period);
+
+    const yr = parseYear(searchParams.get(SIDEBAR_PARAMS.YEAR));
+    if (yr !== null) store.actions.setWeatherYear(yr);
+
+    const vars = parseVars(searchParams.get(SIDEBAR_PARAMS.VAR));
+    if (vars !== null) store.actions.setVariables(vars);
+
+    const gridSize = parseCellSize(searchParams.get(SIDEBAR_PARAMS.GRID));
+    if (gridSize !== null) store.actions.setGridSize(gridSize);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync filter params → URL (replace); separate from bbox/polygon writers
+  const varsStr = useMemo(() => encodeVars(variables), [variables]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(searchParams);
+    let changed = false;
+
+    function maybeSet(key: string, value: string) {
+      if (nextParams.get(key) !== value) {
+        nextParams.set(key, value);
+        changed = true;
+      }
+    }
+    function maybeDelete(key: string) {
+      if (nextParams.has(key)) {
+        nextParams.delete(key);
+        changed = true;
+      }
+    }
+
+    maybeSet(SIDEBAR_PARAMS.DATASET, dataset);
+    maybeSet(SIDEBAR_PARAMS.VAR, varsStr);
+    maybeSet(SIDEBAR_PARAMS.GRID, grid);
+
+    if (isClimate) {
+      maybeSet(SIDEBAR_PARAMS.PERIOD, climatePeriod);
+      maybeDelete(SIDEBAR_PARAMS.YEAR);
+    } else {
+      maybeSet(SIDEBAR_PARAMS.YEAR, String(weatherYear));
+      maybeDelete(SIDEBAR_PARAMS.PERIOD);
+    }
+
+    if (changed) setSearchParams(nextParams, { replace: true });
+  }, [
+    dataset,
+    climatePeriod,
+    weatherYear,
+    isClimate,
+    varsStr,
+    grid,
+    searchParams,
+    setSearchParams,
+  ]);
+
+  // Document title
+  useEffect(() => {
+    const varLabel = VARIABLE_LABELS[activeVariable] ?? activeVariable;
+    const periodStr = isClimate
+      ? (CLIMATE_PERIOD_LABELS[climatePeriod] ?? climatePeriod)
+      : String(weatherYear);
+    document.title = `Region Heatmap · ${varLabel} ${periodStr} | Climatica`;
+  }, [activeVariable, isClimate, climatePeriod, weatherYear]);
 
   const wkt = polygon ? polygonToWkt(polygon) : null;
 
@@ -113,9 +201,22 @@ export function HeatMap() {
     setSearchParams(nextParams, { replace: true });
   }
 
+  function setPolygonInUrl(next: TPolygon | null) {
+    const nextParams = new URLSearchParams(searchParams);
+    if (next) {
+      nextParams.set(SIDEBAR_PARAMS.POLYGON, polygonToWkt(next));
+    } else {
+      nextParams.delete(SIDEBAR_PARAMS.POLYGON);
+    }
+    setSearchParams(nextParams, { replace: true });
+  }
+
   function handleBboxChange(next: TBbox | null) {
     setDrawMode("none");
-    if (next) setPolygon(null);
+    if (next) {
+      setPolygon(null);
+      setPolygonInUrl(null);
+    }
     setBboxInUrl(next);
   }
 
@@ -123,6 +224,7 @@ export function HeatMap() {
     setDrawMode("none");
     setPolygon(next);
     if (next) setBboxInUrl(null);
+    setPolygonInUrl(next);
   }
 
   function handleCitySelect(city: TWikidataCity) {

--- a/src/pages/HeatMap/HeatMap.type.ts
+++ b/src/pages/HeatMap/HeatMap.type.ts
@@ -8,6 +8,13 @@ import type {
   TWorldClimBoxResponse,
 } from "@/types";
 
+export type TLooseBinding = Record<string, unknown>;
+
+export type TSumAndCount = {
+  sum: number;
+  count: number;
+};
+
 export type TRegionalProfile = {
   meanTemp: number;
   annualPrecip: number;

--- a/src/pages/HeatMap/HeatMap.util.ts
+++ b/src/pages/HeatMap/HeatMap.util.ts
@@ -2,7 +2,13 @@ import type { TWorldClimAvgBoxBinding, TWorldClimBoxBinding } from "@/types";
 import { CELL_SIZE_OPTIONS, GRID_DELTA, MONTH_NAMES } from "@/constants";
 import { iriToCellBounds } from "@/utils";
 import type { TCellBounds, TCellSize } from "@/types";
-import type { THeatmapStats, TRegionalProfile } from "./HeatMap.type";
+import type {
+  THeatmapStats,
+  TLooseBinding,
+  TPolygon,
+  TRegionalProfile,
+  TSumAndCount,
+} from "./HeatMap.type";
 
 export { GRID_DELTA, iriToCellBounds };
 export type { TCellBounds, TCellSize };
@@ -21,8 +27,6 @@ const KEY_SETS = [
   Array.from({ length: 12 }, (_, i) => `month${i + 1}`), // month1..12
 ];
 
-type TLooseBinding = Record<string, unknown>;
-
 function extractNumber(raw: unknown): number {
   if (raw === undefined || raw === null) return NaN;
   if (typeof raw === "number") return raw;
@@ -35,7 +39,7 @@ function extractNumber(raw: unknown): number {
   return NaN;
 }
 
-function readMonthlySumAndCount(binding: TLooseBinding): { sum: number; count: number } {
+function readMonthlySumAndCount(binding: TLooseBinding): TSumAndCount {
   for (const keys of KEY_SETS) {
     const first = binding[keys[0]];
     if (first !== undefined) {
@@ -144,6 +148,20 @@ export function polygonToWkt(vertices: [number, number][]): string {
   const ring = [...vertices, vertices[0]];
   const coords = ring.map(([lat, lng]) => `${lng} ${lat}`).join(", ");
   return `POLYGON((${coords}))`;
+}
+
+/** Inverse of polygonToWkt — returns null for invalid WKT */
+export function wktToPolygon(wkt: string): TPolygon | null {
+  const match = /^POLYGON\(\((.+)\)\)$/i.exec(wkt);
+  if (!match) return null;
+  const pairs = match[1].split(",").map((s) => s.trim().split(/\s+/));
+  // WKT is lng lat; drop closing vertex (duplicate of first)
+  const vertices = pairs.slice(0, -1).map(([lng, lat]) => {
+    return [Number(lat), Number(lng)] as [number, number];
+  });
+  if (vertices.length < 3) return null;
+  if (vertices.some(([lat, lng]) => isNaN(lat) || isNaN(lng))) return null;
+  return vertices;
 }
 
 /** "2.5 min" from "2.5 min (~20.25 km²)" */

--- a/src/pages/HeatMap/components/StatsLegendBar.tsx
+++ b/src/pages/HeatMap/components/StatsLegendBar.tsx
@@ -1,14 +1,7 @@
 import { interpolateColor } from "@/utils";
 import { useTranslation } from "react-i18next";
 import type { TStatsLegendBarProps } from "../HeatMap.type";
-
-type TStatBlockProps = {
-  label: string;
-  value: string;
-  subtitle?: string;
-  tooltip?: string;
-  className?: string;
-};
+import type { TSkeletonBlockProps, TStatBlockProps } from "./StatsLegendBar.type";
 
 function StatBlock({ label, value, subtitle, tooltip, className = "" }: TStatBlockProps) {
   return (
@@ -29,7 +22,7 @@ function StatBlock({ label, value, subtitle, tooltip, className = "" }: TStatBlo
   );
 }
 
-function SkeletonBlock({ className = "" }: { className?: string }) {
+function SkeletonBlock({ className = "" }: TSkeletonBlockProps) {
   return (
     <div className={`flex flex-col gap-1.5 px-3 py-2.5 border-[var(--color-border)] ${className}`}>
       <div className="h-2.5 w-10 animate-pulse rounded bg-[var(--color-border)]" />

--- a/src/pages/HeatMap/components/StatsLegendBar.type.ts
+++ b/src/pages/HeatMap/components/StatsLegendBar.type.ts
@@ -1,0 +1,11 @@
+export type TStatBlockProps = {
+  label: string;
+  value: string;
+  subtitle?: string;
+  tooltip?: string;
+  className?: string;
+};
+
+export type TSkeletonBlockProps = {
+  className?: string;
+};

--- a/src/stores/filtersStore.ts
+++ b/src/stores/filtersStore.ts
@@ -1,4 +1,3 @@
-import type { TClimatePeriod } from "@/constants";
 import {
   CELL_SIZES,
   CLIMATE_PERIODS,
@@ -7,32 +6,9 @@ import {
   PERIOD_RESTRICTED_VARIABLES,
   WEATHER_VARIABLES,
 } from "@/constants";
-import type { TCellSize, TDataset, TMonthFilter, TVariable } from "@/types";
+import type { TFiltersData, TFiltersState } from "@/types";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-type TFiltersData = {
-  dataset: TDataset;
-  climatePeriod: TClimatePeriod;
-  weatherYear: number;
-  variables: TVariable[];
-  gridSize: TCellSize;
-  months: TMonthFilter;
-};
-
-type TFiltersState = TFiltersData & {
-  actions: {
-    setDataset: (d: TDataset) => void;
-    setClimatePeriod: (period: TClimatePeriod) => void;
-    setWeatherYear: (year: number) => void;
-    toggleVariable: (v: TVariable) => void;
-    setVariables: (vars: TVariable[]) => void;
-    setGridSize: (g: TCellSize) => void;
-    toggleMonth: (n: number) => void;
-    selectAllMonths: () => void;
-    setMonths: (months: TMonthFilter) => void;
-  };
-};
 
 const DEFAULT_FILTERS: TFiltersData = {
   dataset: DATASETS.CLIMATE,

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -12,6 +12,7 @@ export type {
   TWikidataSparqlBinding,
   TWikidataSparqlResult,
 } from "./wikidata.dto";
+export type { TPopulationResult } from "./wikidata.dto";
 export type {
   TRawAvgValueBinding,
   TRawAvgValueResponse,

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,5 +1,6 @@
 export type { TApiResponse, TResultStatus } from "./common";
 export type {
+  TPopulationResult,
   TWikidataCoords,
   TWikidataEntitiesResult,
   TWikidataEntity,
@@ -12,8 +13,8 @@ export type {
   TWikidataSparqlBinding,
   TWikidataSparqlResult,
 } from "./wikidata.dto";
-export type { TPopulationResult } from "./wikidata.dto";
 export type {
+  TClimatePeriod,
   TRawAvgValueBinding,
   TRawAvgValueResponse,
   TRawPixelValueBinding,

--- a/src/types/api/wikidata.dto.ts
+++ b/src/types/api/wikidata.dto.ts
@@ -56,3 +56,12 @@ export type TWikidataSparqlResult = {
     bindings: TWikidataSparqlBinding[];
   };
 };
+
+export type TPopulationBinding = {
+  settlement: { value: string };
+  population?: { value: string };
+};
+
+export type TPopulationResult = {
+  results: { bindings: TPopulationBinding[] };
+};

--- a/src/types/api/worldclim.dto.ts
+++ b/src/types/api/worldclim.dto.ts
@@ -1,3 +1,5 @@
+import type { TClimatePeriod } from "@/constants/worldclim.constant";
+
 export type TSparqlValue = {
   type: string;
   value: string;
@@ -180,3 +182,5 @@ export type TWorldClimCellResource = {
   iri: string;
   elevation?: number;
 };
+
+export type { TClimatePeriod };

--- a/src/types/domain/climate.ts
+++ b/src/types/domain/climate.ts
@@ -1,10 +1,9 @@
 import { CELL_SIZES, DATASETS } from "@/constants";
-import type { TClimateVariable, TWeatherVariable } from "@/constants/worldclim.constant";
+import type { TClimateVariable, TVariable, TWeatherVariable } from "@/constants/worldclim.constant";
 
 export type TCellSize = (typeof CELL_SIZES)[keyof typeof CELL_SIZES];
 export type TDataset = (typeof DATASETS)[keyof typeof DATASETS];
-export type { TClimateVariable, TWeatherVariable };
-export type TVariable = TClimateVariable | TWeatherVariable;
+export type { TClimateVariable, TVariable, TWeatherVariable };
 export type TMonthFilter = number[] | "all";
 
 export type TMonthlyTemperature = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export type {
   TApiResponse,
+  TClimatePeriod,
   TPopulationResult,
   TRawAvgValueBinding,
   TRawAvgValueResponse,
@@ -56,6 +57,7 @@ export type {
   TUseGetCompareDataReturn,
   TUseGetComparePeriodsReturn,
 } from "./hooks";
+export type { TFiltersData, TFiltersState } from "./stores";
 export type { TCellSizeOption } from "./ui";
 export type {
   TCellBounds,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export type {
   TApiResponse,
+  TPopulationResult,
   TRawAvgValueBinding,
   TRawAvgValueResponse,
   TRawPixelValueBinding,

--- a/src/types/stores/filtersStore.type.ts
+++ b/src/types/stores/filtersStore.type.ts
@@ -1,0 +1,25 @@
+import type { TClimatePeriod } from "@/constants";
+import type { TCellSize, TDataset, TMonthFilter, TVariable } from "@/types";
+
+export type TFiltersData = {
+  dataset: TDataset;
+  climatePeriod: TClimatePeriod;
+  weatherYear: number;
+  variables: TVariable[];
+  gridSize: TCellSize;
+  months: TMonthFilter;
+};
+
+export type TFiltersState = TFiltersData & {
+  actions: {
+    setDataset: (d: TDataset) => void;
+    setClimatePeriod: (period: TClimatePeriod) => void;
+    setWeatherYear: (year: number) => void;
+    toggleVariable: (v: TVariable) => void;
+    setVariables: (vars: TVariable[]) => void;
+    setGridSize: (g: TCellSize) => void;
+    toggleMonth: (n: number) => void;
+    selectAllMonths: () => void;
+    setMonths: (months: TMonthFilter) => void;
+  };
+};

--- a/src/types/stores/filtersStore.type.ts
+++ b/src/types/stores/filtersStore.type.ts
@@ -1,5 +1,4 @@
-import type { TClimatePeriod } from "@/constants";
-import type { TCellSize, TDataset, TMonthFilter, TVariable } from "@/types";
+import type { TCellSize, TClimatePeriod, TDataset, TMonthFilter, TVariable } from "@/types";
 
 export type TFiltersData = {
   dataset: TDataset;

--- a/src/types/stores/index.ts
+++ b/src/types/stores/index.ts
@@ -1,0 +1,1 @@
+export type { TFiltersData, TFiltersState } from "./filtersStore.type";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,17 @@ export {
 } from "./walterLieth.util";
 export { isValidString, parseWktPoint } from "./wikidata.util";
 export {
+  encodeMonths,
+  encodeVars,
+  parseCellSize,
+  parseCoord,
+  parseDataset,
+  parseMonths,
+  parsePeriod,
+  parseVars,
+  parseYear,
+} from "./urlParams.util";
+export {
   buildDatasetParams,
   buildGridIri,
   buildMonthlyTemperatures,

--- a/src/utils/urlParams.util.ts
+++ b/src/utils/urlParams.util.ts
@@ -1,0 +1,76 @@
+import {
+  CELL_SIZES,
+  CLIMATE_PERIODS,
+  CLIMATE_VARIABLES,
+  DATASETS,
+  WEATHER_MAX_YEAR,
+  WEATHER_MIN_YEAR,
+} from "@/constants";
+import type { TCellSize, TClimatePeriod, TDataset, TMonthFilter, TVariable } from "@/types";
+
+const VALID_VARIABLES = new Set<string>(CLIMATE_VARIABLES);
+const VALID_CELL_SIZES = new Set<string>(Object.values(CELL_SIZES));
+const VALID_PERIODS = new Set<string>(Object.values(CLIMATE_PERIODS));
+const VALID_DATASETS = new Set<string>(Object.values(DATASETS));
+
+export function parseDataset(raw: string | null): TDataset | null {
+  if (raw !== null && VALID_DATASETS.has(raw)) return raw as TDataset;
+  return null;
+}
+
+export function parsePeriod(raw: string | null): TClimatePeriod | null {
+  if (raw !== null && VALID_PERIODS.has(raw)) return raw as TClimatePeriod;
+  return null;
+}
+
+export function parseYear(raw: string | null): number | null {
+  if (raw === null) return null;
+
+  const n = parseInt(raw, 10);
+  if (isNaN(n) || n < WEATHER_MIN_YEAR || n > WEATHER_MAX_YEAR) return null;
+
+  return n;
+}
+
+export function parseVars(raw: string | null): TVariable[] | null {
+  if (raw === null) return null;
+
+  const parsed = raw.split(",").filter((v) => VALID_VARIABLES.has(v)) as TVariable[];
+
+  return parsed.length > 0 ? parsed : null;
+}
+
+export function parseCellSize(raw: string | null): TCellSize | null {
+  if (raw !== null && VALID_CELL_SIZES.has(raw)) return raw as TCellSize;
+  return null;
+}
+
+export function parseMonths(raw: string | null): TMonthFilter | null {
+  if (raw === null) return null;
+  if (raw === "all") return "all";
+
+  const nums = raw
+    .split(",")
+    .map(Number)
+    .filter((n) => Number.isInteger(n) && n >= 1 && n <= 12);
+
+  if (nums.length === 0) return null;
+
+  return nums.length === 12 ? "all" : nums;
+}
+
+export function parseCoord(raw: string | null): number | null {
+  if (raw === null) return null;
+
+  const n = parseFloat(raw);
+
+  return isNaN(n) ? null : n;
+}
+
+export function encodeVars(vars: TVariable[]): string {
+  return vars.join(",");
+}
+
+export function encodeMonths(months: TMonthFilter): string {
+  return months === "all" ? "all" : months.join(",");
+}

--- a/src/validators/filters.validator.ts
+++ b/src/validators/filters.validator.ts
@@ -2,10 +2,7 @@ import { CLIMATE_PERIODS, WEATHER_MAX_YEAR, WEATHER_MIN_YEAR } from "@/constants
 import { z } from "zod";
 
 export const weatherYearSchema = z
-  .number({
-    required_error: "validation.year.required",
-    invalid_type_error: "validation.year.invalid",
-  })
+  .number({ error: "validation.year.invalid" })
   .int("validation.year.integer")
   .min(WEATHER_MIN_YEAR, "validation.year.tooSmall")
   .max(WEATHER_MAX_YEAR, "validation.year.tooBig");


### PR DESCRIPTION
## Updates

### Shareable URLs
All four pages now encode complete filter state into URL params —
any URL can be copied and opened to restore the exact view.

City Climate: `?city=Burgos&lat=42.34&lng=-3.70&dataset=weather&year=2024&var=tmax&grid=2.5m&month=all`
Compare Cities: `?cityA=Rome&latA=41.90&lngA=12.48&cityB=Oslo&latB=59.91&lngB=10.75&dataset=climate&period=c1970-2000`
Compare Periods: `?city=Madrid&lat=40.42&lng=-3.70&period1=c1951-1980&period2=c1991-2020&var=tmax`
Heatmap: `?north=51.6&south=51.4&west=-0.2&east=0.1&var=tmax&dataset=weather&year=2024&polygon=POLYGON(...)`

Implementation details:
- All param keys centralised in `SIDEBAR_PARAMS` — no magic strings
- New `urlParams.util.ts` — typed, defensive parse/encode helpers;
  invalid values return null rather than silently coercing
- Filter changes: `replace: true` — no history pollution
- City selection: `replace: false` — back button navigates between cities
- WKT ↔ polygon roundtrip: `wktToPolygon` added to complement
  existing `polygonToWkt` so drawn polygons survive page reload
- Dynamic `document.title` on every page:
  "Burgos · tmax 2024 | Climatica"

### Bug fix
- `TClimatePeriod` circular dependency resolved — type defined once
  in `worldclim.constant.ts`, re-exported through constants barrel;
  eliminates 15 cascading ESLint no-unsafe-* errors

### CI
- GitHub Actions workflow on every push/PR to main:
  type-check → lint → build

### Docs
- `AGENTS.md` — project conventions for AI-assisted development

## Test plan
- Open each page with no params — verify defaults load and URL populates
- Copy URL, open in new tab — verify full state restores correctly
- Draw polygon on Heatmap, reload — polygon reappears
- Select city — back button returns to previous city
- Change filter — back button skips filter changes (replace)